### PR TITLE
Change pdf-engine flag to latex-engine like in Pandoc

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 TEX = pandoc
 src = template.tex details.yml
-FLAGS = --pdf-engine=xelatex
+FLAGS = --latex-engine=xelatex
 
 output.pdf : $(src)
 	$(TEX) $(filter-out $<,$^ ) -o $@ --template=$< $(FLAGS)


### PR DESCRIPTION
Pandoc has changed the pdf-engine flag to latex-engine sometime recently. Thought you might want to update it.