### PR TITLE
updated makefile to work with pandoc

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 TEX = pandoc
 src = template.tex details.yml
-FLAGS = --pdf-engine=xelatex
+FLAGS = --latex-engine=xelatex
 
 output.pdf : $(src)
 	$(TEX) $(filter-out $<,$^ ) -o $@ --template=$< $(FLAGS)


### PR DESCRIPTION
Pandoc was throwing an error because the name of the flag --pdf-engine got appears to have been updated to --latex-engine.

I'm running texlive 2018 on Ubuntu 18.04 and installed pandoc 1.19.2.4 from the apt repositories. Sorry if this doesn't belong here!