### PR TITLE
Change language key to IETF format.

### DIFF
--- a/details.yml
+++ b/details.yml
@@ -49,6 +49,6 @@ education:
 # Settings
 mainfont: Hoefler Text
 fontsize: 10pt
-lang: English
+lang: en-GB
 geometry: a4paper, left=35mm, right=35mm, top=51mm, bottom=17mm
 ---


### PR DESCRIPTION
After trying to `make` after initial clone I received the following error:

```
pandoc details.yml -o output.pdf --template=template.tex --pdf-engine=xelatex
[WARNING] Could not deduce format from file extension .yml
  Defaulting to markdown
[WARNING] Invalid 'lang' value 'English'.
  Use an IETF language tag like 'en-US'.
Error producing PDF.
! LaTeX3 Error: The key 'polyglossia/English/hyphenmins' requires a value.

For immediate help type H <return>.
 ...                                              
                                                  
l.26 \setmainlanguage{English}

make: *** [output.pdf] Error 43
```

Replacing the language key with the IETF language tag `en-GB` fixes the issue.

I have installed the latest (as of 2020/07/19) xelatex which was installed via`brew install mactex` so I assume this issue is caused by updates to the ~xelatex~ polyglossia package. 